### PR TITLE
Fixed GIST_REGEXP & stylesheet href

### DIFF
--- a/jquery.gist.js
+++ b/jquery.gist.js
@@ -4,6 +4,7 @@
 
     var GIST_URL = "https://gist.github.com",
         GIST_REGEXP = /^https?:\/\/gist\.github\.com(?:\/[^/]+)*\/([0-9a-z]+)\/?$/,
+        
         $stylesheetContainer = $("head"),
         stylesheetLoaded = false,
         defaults = {

--- a/jquery.gist.js
+++ b/jquery.gist.js
@@ -3,7 +3,7 @@
     "use strict";
 
     var GIST_URL = "https://gist.github.com",
-        GIST_REGEXP = /^https?:\/\/gist\.github\.com(?:\/[^/]+)*\/([0-9]+)\/?$/,
+        GIST_REGEXP = /^https?:\/\/gist\.github\.com(?:\/[^/]+)*\/([0-9a-z]+)\/?$/,
         $stylesheetContainer = $("head"),
         stylesheetLoaded = false,
         defaults = {
@@ -43,9 +43,9 @@
         .done(function(response) {
             if (response.stylesheet && !stylesheetLoaded) {
                 stylesheetLoaded = true;
-
+                
                 $stylesheetContainer.append(
-                    "<link rel='stylesheet' href='" + GIST_URL + response.stylesheet + "' type='text/css' />"
+                    "<link rel='stylesheet' href='" + response.stylesheet + "' type='text/css' />"
                 );
             }
 


### PR DESCRIPTION
Gist example: https://gist.github.com/its2loud/ae559a0d6a52ecee3c9f
• the GIST_REGEXP needed to look for letters too
• the stylesheet url already begins with "https://gist-assets.github.com/assets/" so I left out the variable GIST_URL in order to fix it.
